### PR TITLE
Allow private RDS clusters

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,25 +45,28 @@ Before using this module, you must have the following:
 
 ## Running the module
 
-1. Clone the repository:
+### Variables
 
-    ```bash
-    git clone https://github.com/bobbyiliev/terraform-materialize-rds.git
-    ```
+Copy the `terraform.tfvars.example` file to `terraform.tfvars` and fill in the variables:
 
-2. Copy the `terraform.tfvars.example` file to `terraform.tfvars` and fill in the variables:
+```bash
+cp terraform.tfvars.example terraform.tfvars
+```
 
-    ```bash
-    cp terraform.tfvars.example terraform.tfvars
-    ```
+| Name | Description | Type | Example | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| mz_egress_ips | Materialize instance egress IP addresses | list(string) | ["123.456.789.0/32", "123.456.789.1/32"] | yes |
+| publicly_accessible | Whether the RDS instance is publicly accessible | bool | true | no |
 
-3. Add the Materialize instance egress IP addresses to the `mz_egress_ips` variable in `terraform.tfvars`:
+### Apply the Terraform Module
+
+1. Add the Materialize instance egress IP addresses to the `mz_egress_ips` variable in `terraform.tfvars`:
 
     ```bash
     mz_egress_ips = ["123.456.789.0/32", "123.456.789.1/32"]
     ```
 
-4. Apply the Terraform configuration:
+1. Apply the Terraform configuration:
 
     ```bash
     terraform apply
@@ -71,7 +74,7 @@ Before using this module, you must have the following:
 
     Once you run the command, it might take a few minutes for the RDS instance to be created.
 
-5. Check the output:
+1. Check the output:
 
     ```bash
     terraform output -raw mz_rds_details

--- a/main.tf
+++ b/main.tf
@@ -69,8 +69,8 @@ resource "aws_db_instance" "mz_rds_demo_db" {
   vpc_security_group_ids = [aws_security_group.mz_rds_demo_sg.id]
   parameter_group_name   = aws_db_parameter_group.mz_rds_demo_pg.name
   apply_immediately      = true
-  # Publicly accessible for demo purposes
-  publicly_accessible  = true
+  # Publicly accessible by default for demo purposes
+  publicly_accessible  = var.publicly_accessible
   skip_final_snapshot  = true
   db_subnet_group_name = aws_db_subnet_group.mz_rds_demo_db_subnet_group.name
 }

--- a/variables.tf
+++ b/variables.tf
@@ -10,3 +10,10 @@ variable "mz_egress_ips" {
   description = "List of Materialize egress IPs"
   type        = list(any)
 }
+
+# Publicly accessible or not
+variable "publicly_accessible" {
+  description = "Whether the RDS instance is publicly accessible or not"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
As this module might be used for testing the RDS + PrivateLink implementation, we would need to be able to create private RDS instances as well.

Exposing the `publicly_accessible` attribute so the end user could decide if they want this to be a public or a private cluster.