### PR TITLE
Use instance name for related resouces

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ cp terraform.tfvars.example terraform.tfvars
 | Name                  | Description                              | Type         | Example                                    | Required |
 |-----------------------|------------------------------------------|:------------:|:------------------------------------------:|:--------:|
 | `mz_egress_ips`       | Materialize instance egress IP addresses | list(string) | `["123.456.789.0/32", "123.456.789.1/32"]` | yes      |
+| `rds_instance_name`   | The name of the RDS instance             | string       | `mz-rds-demo-db`                           | yes      |
 | `publicly_accessible` | Whether the RDS is publicly accessible   | `bool`       | true                                       | no       |
-| `rds_instance_name`   | The name of the RDS instance             | string       | `mz-rds-demo-db`                           | no       |
 
 ### Apply the Terraform Module
 

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@ module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
   version = "3.19.0"
 
-  name                 = "mz_rds_demo_vpc"
+  name                 = "${var.rds_instance_name}-vpc"
   cidr                 = "10.0.0.0/16"
   azs                  = data.aws_availability_zones.available.names
   public_subnets       = ["10.0.4.0/24", "10.0.5.0/24"]
@@ -11,7 +11,7 @@ module "vpc" {
 }
 
 resource "aws_db_subnet_group" "mz_rds_demo_db_subnet_group" {
-  name       = "mz_rds_demo_db_subnet_group"
+  name       = "${var.rds_instance_name}-db-subnet-group"
   subnet_ids = module.vpc.public_subnets
 
   tags = {
@@ -20,7 +20,7 @@ resource "aws_db_subnet_group" "mz_rds_demo_db_subnet_group" {
 }
 
 resource "aws_security_group" "mz_rds_demo_sg" {
-  name        = "mz_rds_demo_vpc"
+  name        = "${var.rds_instance_name}-sg"
   description = "Materialize RDS Terraform demo"
   vpc_id      = module.vpc.vpc_id
 
@@ -58,7 +58,7 @@ resource "aws_db_parameter_group" "mz_rds_demo_pg" {
 }
 
 resource "aws_db_instance" "mz_rds_demo_db" {
-  identifier             = "mz-rds-demo-db"
+  identifier             = var.rds_instance_name
   allocated_storage      = 20
   engine                 = "postgres"
   engine_version         = "13"

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -3,3 +3,6 @@ aws_region = "us-east-1"
 
 # Get the Materialize Egress IPs, eg. `SELECT * FROM mz_egress_ips;`
 mz_egress_ips=[""]
+
+# RDS instance name
+rds_instance_name = "mz-rds-demo-db"

--- a/variables.tf
+++ b/variables.tf
@@ -15,7 +15,7 @@ variable "mz_egress_ips" {
 variable "publicly_accessible" {
   description = "Whether the RDS instance is publicly accessible or not"
   type        = bool
-  default     = false
+  default     = true
 }
 
 # Name of the RDS instance

--- a/variables.tf
+++ b/variables.tf
@@ -20,7 +20,6 @@ variable "publicly_accessible" {
 
 # Name of the RDS instance
 variable "rds_instance_name" {
-  description = "Name of the RDS instance"
+  description = "The name of the RDS instance"
   type        = string
-  default     = "mz-rds-demo-pg"
 }


### PR DESCRIPTION
As reported by @aalexandrov the names of the resources were hardcoded into the main.tf file. Abstracting this away for all resources to use the `rds_instance_name` variable so we can spin up multiple instances in the same region.