### PR TITLE
Expose RDS database properties as module outputs

### DIFF
--- a/output.tf
+++ b/output.tf
@@ -1,3 +1,7 @@
+output "rds_instance" {
+  value = aws_db_instance.mz_rds_demo_db
+}
+
 output "mz_rds_details" {
   sensitive = true
   value     = <<EOF


### PR DESCRIPTION
When using this as a module in other projects, one might need to connect to the RDS database, so the connection properties need to be exposed as an output.