### PR TITLE
Expose instance class and version as vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ cp terraform.tfvars.example terraform.tfvars
 | `mz_egress_ips`       | Materialize instance egress IP addresses | list(string) | `["123.456.789.0/32", "123.456.789.1/32"]` | yes      |
 | `rds_instance_name`   | The name of the RDS instance             | string       | `mz-rds-demo-db`                           | yes      |
 | `publicly_accessible` | Whether the RDS is publicly accessible   | `bool`       | true                                       | no       |
+| `rds_instance_class`  | The RDS instance class                   | string       | `db.m5.large`                              | no       |
+| `engine_version`      | The RDS engine version                   | string       | `14`                                       | no       |
 
 ### Apply the Terraform Module
 

--- a/main.tf
+++ b/main.tf
@@ -61,8 +61,8 @@ resource "aws_db_instance" "mz_rds_demo_db" {
   identifier             = var.rds_instance_name
   allocated_storage      = 20
   engine                 = "postgres"
-  engine_version         = "13"
-  instance_class         = "db.m5.large"
+  engine_version         = var.engine_version
+  instance_class         = var.rds_instance_class
   db_name                = "materialize"
   username               = "materialize"
   password               = random_string.mz_rds_demo_db_password.result

--- a/variables.tf
+++ b/variables.tf
@@ -23,3 +23,17 @@ variable "rds_instance_name" {
   description = "The name of the RDS instance"
   type        = string
 }
+
+# RDS instance size
+variable "rds_instance_class" {
+  description = "The size of the RDS instance"
+  type        = string
+  default     = "db.m5.large"
+}
+
+# RDS instance engine version
+variable "engine_version" {
+  description = "The engine version of the RDS instance"
+  type        = string
+  default     = "14"
+}


### PR DESCRIPTION
Currently the instance class and engine versions are hardcoded and can only be changed manually.

Also setting the default engine version to 14.x rather than 13.x due to the following limitation which might be a blocker in the future:

>  You can’t create a read replica from another read replica if your RDS for PostgreSQL DB instance is running a PostgreSQL version earlier than 14.1.
