### PR TITLE
Use the right `aws_db_parameter_group` family

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -48,7 +48,7 @@ resource "random_string" "mz_rds_demo_db_password" {
 
 resource "aws_db_parameter_group" "mz_rds_demo_pg" {
   name   = var.rds_instance_name
-  family = "postgres13"
+  family = "postgres${var.engine_version}"
 
   parameter {
     name         = "rds.logical_replication"


### PR DESCRIPTION
Infer the value passed to the `aws_db_parameter_group` family from the current `engine_version` variable value.